### PR TITLE
Replacing the function noise.noiseQU_freq which doesnt exist

### DIFF
--- a/cobi/simulation/noise.py
+++ b/cobi/simulation/noise.py
@@ -426,3 +426,17 @@ class Noise:
             return self.noiseQU_TOD(idx)
         else:
             raise ValueError(f"Invalid simulation type: {self.sim}", "Choose from 'NC' or 'TOD'.")
+
+    def noiseQU_freq(self, idx: int, freq: str) -> np.ndarray:
+        """
+        Generates Q and U polarization noise maps for a specific frequency band.
+
+        Returns:
+        np.ndarray: An array of Q and U noise maps for the specified frequency band.
+        """
+        if self.sim == 'NC':
+            return self.noiseQU_NC_freq(idx, freq)
+        elif self.sim == 'TOD':
+            return self.noiseQU_TOD_freq(idx, freq)
+        else:
+            raise ValueError(f"Invalid simulation type: {self.sim}", "Choose from 'NC' or 'TOD'.")

--- a/cobi/simulation/sky.py
+++ b/cobi/simulation/sky.py
@@ -246,7 +246,10 @@ class SkySimulation:
                 alpha = self.get_alpha(idx, band)
                 signal = self.obsQUwAlpha(idx, band, fwhm, alpha)
                 #noise = self.noise.atm_noise_maps_freq(idx, band)
-                noise = self.noise.noiseQU_freq(idx, band)
+                if self.noise_model=='NC':
+                    noise = self.noise.noiseQU_NC_freq(idx, band)
+                elif self.noise_model=='TOD':
+                    noise = self.noise.noiseQU_TOD_freq(idx, band)
                 if len(noise) > 2:
                     nside = hp.get_nside(noise[0])
                 else:

--- a/cobi/simulation/sky.py
+++ b/cobi/simulation/sky.py
@@ -246,10 +246,7 @@ class SkySimulation:
                 alpha = self.get_alpha(idx, band)
                 signal = self.obsQUwAlpha(idx, band, fwhm, alpha)
                 #noise = self.noise.atm_noise_maps_freq(idx, band)
-                if self.noise_model=='NC':
-                    noise = self.noise.noiseQU_NC_freq(idx, band)
-                elif self.noise_model=='TOD':
-                    noise = self.noise.noiseQU_TOD_freq(idx, band)
+                noise = self.noise.noiseQU_freq(idx, band)
                 if len(noise) > 2:
                     nside = hp.get_nside(noise[0])
                 else:


### PR DESCRIPTION
The line `noise = self.noise.noiseQU_freq(idx, band)` fails because the method `noiseQU_freq` does not exist. Is this the proper way of fixing it?